### PR TITLE
Feature: partially use Ne when `usedNe` < `Ne`.

### DIFF
--- a/gen_twopt_diagram.py
+++ b/gen_twopt_diagram.py
@@ -81,10 +81,10 @@ for cfg in ["2000"]:
 
     t_snk = numpy.arange(128)
 
-    eta_src.load(cfg)
-    eta_snk.load(cfg)
-    propag.load(cfg)
-    propag_local.load(cfg)
+    eta_src.load(cfg, usedNe=50)
+    eta_snk.load(cfg, usedNe=50)
+    propag.load(cfg, usedNe=50)
+    propag_local.load(cfg, usedNe=50)
 
     twopt = backend.zeros((2, 128))
     for t_src in range(128):
@@ -102,10 +102,10 @@ for cfg in ["2000"]:
     print(twopt)
     print(backend.arccosh((backend.roll(twopt, -1, 1) + backend.roll(twopt, 1, 1)) / twopt / 2))
 
-    rho_src.load(cfg)
-    pi_snk.load(cfg)
-    propag.load(cfg)
-    propag_local.load(cfg)
+    rho_src.load(cfg, usedNe=50)
+    pi_snk.load(cfg, usedNe=50)
+    propag.load(cfg, usedNe=50)
+    propag_local.load(cfg, usedNe=50)
 
     twopt = backend.zeros((1, 128))
     for t_src in range(128):

--- a/lattice/correlator/disperion_relation.py
+++ b/lattice/correlator/disperion_relation.py
@@ -24,6 +24,7 @@ def twopoint_mom2(
     perambulator: FileData,
     timeslices: Iterable[int],
     Lt: int,
+    usedNe: int = None
 ):
     operators = get_mom2_oprator(insertion_row, mom2)
-    return twopoint([operators], elemental, perambulator, timeslices, Lt)
+    return twopoint([operators], elemental, perambulator, timeslices, Lt, usedNe)

--- a/lattice/correlator/disperion_relation.py
+++ b/lattice/correlator/disperion_relation.py
@@ -24,7 +24,7 @@ def twopoint_mom2(
     perambulator: FileData,
     timeslices: Iterable[int],
     Lt: int,
-    usedNe: int = None
+    usedNe: int = None,
 ):
     operators = get_mom2_oprator(insertion_row, mom2)
     return twopoint([operators], elemental, perambulator, timeslices, Lt, usedNe)

--- a/lattice/correlator/one_particle.py
+++ b/lattice/correlator/one_particle.py
@@ -10,7 +10,12 @@ from ..backend import get_backend
 
 
 def twopoint(
-    operators: List[Operator], elemental: FileData, perambulator: FileData, timeslices: Iterable[int], Lt: int, usedNe: int = None 
+    operators: List[Operator],
+    elemental: FileData,
+    perambulator: FileData,
+    timeslices: Iterable[int],
+    Lt: int,
+    usedNe: int = None,
 ):
     backend = get_backend()
     Nop = len(operators)
@@ -23,8 +28,14 @@ def twopoint(
         tau_bw = contract("ii,tjiba,jj->tijab", gamma(15), tau.conj(), gamma(15))
         for idx in range(Nop):
             phi = phis[idx]
-            print(tau_bw.shape, phi[0].shape, backend.roll(phi[1], -t, 1).shape, tau.shape, phi[0].shape,
-                phi[1][:, t].conj().shape)
+            print(
+                tau_bw.shape,
+                phi[0].shape,
+                backend.roll(phi[1], -t, 1).shape,
+                tau.shape,
+                phi[0].shape,
+                phi[1][:, t].conj().shape,
+            )
             ret[idx] += contract(
                 "tijab,xjk,xtbc,tklcd,yli,yad->t",
                 tau_bw,
@@ -41,7 +52,12 @@ def twopoint(
 
 
 def twopoint_matrix(
-    operators: List[Operator], elemental: FileData, perambulator: FileData, timeslices: Iterable[int], Lt: int, usedNe:int = None
+    operators: List[Operator],
+    elemental: FileData,
+    perambulator: FileData,
+    timeslices: Iterable[int],
+    Lt: int,
+    usedNe: int = None,
 ):
     backend = get_backend()
     Nop = len(operators)
@@ -72,7 +88,12 @@ def twopoint_matrix(
 
 
 def twopoint_isoscalar(
-    operators: List[Operator], elemental: FileData, perambulator: FileData, timeslices: Iterable[int], Lt: int, usedNe: int = None
+    operators: List[Operator],
+    elemental: FileData,
+    perambulator: FileData,
+    timeslices: Iterable[int],
+    Lt: int,
+    usedNe: int = None,
 ):
     backend = get_backend()
     Nop = len(operators)
@@ -119,7 +140,7 @@ def twopoint_matrix_multi_mom(
     perambulator: FileData,
     timeslices: Iterable[int],
     Lt: int,
-    usedNe:int = None,
+    usedNe: int = None,
     insertions_coeff_list: List = None,
 ):
     backend = get_backend()

--- a/lattice/correlator/one_particle.py
+++ b/lattice/correlator/one_particle.py
@@ -10,19 +10,21 @@ from ..backend import get_backend
 
 
 def twopoint(
-    operators: List[Operator], elemental: FileData, perambulator: FileData, timeslices: Iterable[int], Lt: int
+    operators: List[Operator], elemental: FileData, perambulator: FileData, timeslices: Iterable[int], Lt: int, usedNe: int = None 
 ):
     backend = get_backend()
     Nop = len(operators)
     Nt = len(timeslices)
 
     ret = backend.zeros((Nop, Lt), "<c16")
-    phis = get_elemental_data(operators, elemental)
+    phis = get_elemental_data(operators, elemental, usedNe)
     for t in timeslices:
-        tau = perambulator[t]
+        tau = perambulator[t, :, :, :, :usedNe, :usedNe]
         tau_bw = contract("ii,tjiba,jj->tijab", gamma(15), tau.conj(), gamma(15))
         for idx in range(Nop):
             phi = phis[idx]
+            print(tau_bw.shape, phi[0].shape, backend.roll(phi[1], -t, 1).shape, tau.shape, phi[0].shape,
+                phi[1][:, t].conj().shape)
             ret[idx] += contract(
                 "tijab,xjk,xtbc,tklcd,yli,yad->t",
                 tau_bw,
@@ -39,16 +41,16 @@ def twopoint(
 
 
 def twopoint_matrix(
-    operators: List[Operator], elemental: FileData, perambulator: FileData, timeslices: Iterable[int], Lt: int
+    operators: List[Operator], elemental: FileData, perambulator: FileData, timeslices: Iterable[int], Lt: int, usedNe:int = None
 ):
     backend = get_backend()
     Nop = len(operators)
     Nt = len(timeslices)
 
     ret = backend.zeros((Nop, Nop, Lt), "<c16")
-    phis = get_elemental_data(operators, elemental)
+    phis = get_elemental_data(operators, elemental, usedNe)
     for t in timeslices:
-        tau = perambulator[t]
+        tau = perambulator[t, :, :, :, :usedNe, :usedNe]
         tau_bw = contract("ii,tjiba,jj->tijab", gamma(15), tau.conj(), gamma(15))
         for isrc in range(Nop):
             for isnk in range(Nop):
@@ -70,7 +72,7 @@ def twopoint_matrix(
 
 
 def twopoint_isoscalar(
-    operators: List[Operator], elemental: FileData, perambulator: FileData, timeslices: Iterable[int], Lt: int
+    operators: List[Operator], elemental: FileData, perambulator: FileData, timeslices: Iterable[int], Lt: int, usedNe: int = None
 ):
     backend = get_backend()
     Nop = len(operators)
@@ -81,10 +83,10 @@ def twopoint_isoscalar(
     connected = backend.zeros((Nop, Lt), "<c16")
     loop_src = backend.zeros((Nop, Lt), "<c16")
     loop_snk = backend.zeros((Nop, Lt), "<c16")
-    phis = get_elemental_data(operators, elemental)
+    phis = get_elemental_data(operators, elemental, usedNe)
 
     for t in timeslices:
-        tau = perambulator[t]
+        tau = perambulator[t, :, :, :, :usedNe, :usedNe]
         tau_bw = contract("ii,tjiba,jj->tijab", gamma(15), tau.conj(), gamma(15))
         for idx in range(Nop):
             phi = phis[idx]
@@ -117,6 +119,7 @@ def twopoint_matrix_multi_mom(
     perambulator: FileData,
     timeslices: Iterable[int],
     Lt: int,
+    usedNe:int = None,
     insertions_coeff_list: List = None,
 ):
     backend = get_backend()
@@ -137,10 +140,10 @@ def twopoint_matrix_multi_mom(
     Nterm = Nmom * Nop * Nop
 
     ret = backend.zeros((Nterm, Lt), "<c16")
-    phis_src = get_elemental_data(op_src_list, elemental)
-    phis_snk = get_elemental_data(op_snk_list, elemental)
+    phis_src = get_elemental_data(op_src_list, elemental, usedNe)
+    phis_snk = get_elemental_data(op_snk_list, elemental, usedNe)
     for t in timeslices:
-        tau = perambulator[t]
+        tau = perambulator[t, :, :, :, :usedNe, :usedNe]
         tau_bw = contract("ii,tjiba,jj->tijab", gamma(15), tau.conj(), gamma(15))
         for item in range(Nterm):
             phi_src = phis_src[item]

--- a/lattice/data.py
+++ b/lattice/data.py
@@ -4,7 +4,7 @@ from .insertion import Operator
 from .filedata.abstract import FileData
 
 
-def get_elemental_data(operators: List[Operator], elemental: FileData):
+def get_elemental_data(operators: List[Operator], elemental: FileData, usedNe: int):
     from .backend import get_backend
     from .insertion.gamma import gamma
 
@@ -23,7 +23,7 @@ def get_elemental_data(operators: List[Operator], elemental: FileData):
                 elemental_coeff, derivative_idx, momentum_idx = elemental_part[j]
                 deriv_mom_tuple = (derivative_idx, momentum_idx)
                 if deriv_mom_tuple not in cache:
-                    cache[deriv_mom_tuple] = elemental[derivative_idx, momentum_idx]
+                    cache[deriv_mom_tuple] = elemental[derivative_idx, momentum_idx, :, :usedNe, :usedNe]
                 if j == 0:
                     ret_elemental.append(elemental_coeff * cache[deriv_mom_tuple])
                 else:

--- a/lattice/quark_diagram.py
+++ b/lattice/quark_diagram.py
@@ -114,7 +114,9 @@ class Meson(Particle):
                 elemental_coeff, derivative_idx, momentum_idx = elemental_part[j]
                 deriv_mom_tuple = (derivative_idx, momentum_idx)
                 if deriv_mom_tuple not in cache:
-                    cache[deriv_mom_tuple] = self.elemental_data[derivative_idx, momentum_idx,  :, :self.usedNe, :self.usedNe]
+                    cache[deriv_mom_tuple] = self.elemental_data[
+                        derivative_idx, momentum_idx, :, : self.usedNe, : self.usedNe
+                    ]
                 if j == 0:
                     ret_elemental.append(elemental_coeff * cache[deriv_mom_tuple])
                 else:
@@ -153,7 +155,7 @@ class Propagator:
         self.cache_dagger = None
         self.cached_time = None
 
-    def load(self, key, usedNe:int = None):
+    def load(self, key, usedNe: int = None):
         if self.key != key:
             self.key = key
             self.usedNe = usedNe
@@ -164,7 +166,7 @@ class Propagator:
 
         if isinstance(t_source, int) and isinstance(t_sink, int):
             if self.cached_time != t_source and self.cached_time != t_sink:
-                self.cache = self.perambulator_data[t_source, :, :, :, :self.usedNe, :self.usedNe]
+                self.cache = self.perambulator_data[t_source, :, :, :, : self.usedNe, : self.usedNe]
                 self.cache_dagger = contract("ik,tlkba,lj->tijab", gamma(15), self.cache.conj(), gamma(15))
                 self.cached_time = t_source
             if self.cached_time == t_source:
@@ -173,13 +175,13 @@ class Propagator:
                 return self.cache_dagger[(t_source - t_sink) % self.Lt]
         elif isinstance(t_source, int):
             if self.cached_time != t_source:
-                self.cache = self.perambulator_data[t_source, :, :, :, :self.usedNe, :self.usedNe]
+                self.cache = self.perambulator_data[t_source, :, :, :, : self.usedNe, : self.usedNe]
                 self.cache_dagger = contract("ik,tlkba,lj->tijab", gamma(15), self.cache.conj(), gamma(15))
                 self.cached_time = t_source
             return self.cache[(t_sink - t_source) % self.Lt]
         elif isinstance(t_sink, int):
             if self.cached_time != t_sink:
-                self.cache = self.perambulator_data[t_sink, :, :, :, :self.usedNe, :self.usedNe]
+                self.cache = self.perambulator_data[t_sink, :, :, :, : self.usedNe, : self.usedNe]
                 self.cache_dagger = contract("ik,tlkba,lj->tijab", gamma(15), self.cache.conj(), gamma(15))
                 self.cached_time = t_sink
             return self.cache_dagger[(t_source - t_sink) % self.Lt]
@@ -194,7 +196,7 @@ class PropagatorLocal:
         self.Lt = Lt
         self.cache = None
 
-    def load(self, key, usedNe:int = None):
+    def load(self, key, usedNe: int = None):
         if self.key != key:
             self.key = key
             self.perambulator_data = self.perambulator.load(key)
@@ -202,9 +204,9 @@ class PropagatorLocal:
             self._make_cache()
 
     def _make_cache(self):
-        self.cache = self.perambulator_data[0, :, :, :, :self.usedNe, :self.usedNe]
+        self.cache = self.perambulator_data[0, :, :, :, : self.usedNe, : self.usedNe]
         for t_source in range(1, self.Lt):
-            self.cache[t_source] = self.perambulator_data[t_source, 0, :, :, :self.usedNe, :self.usedNe]
+            self.cache[t_source] = self.perambulator_data[t_source, 0, :, :, : self.usedNe, : self.usedNe]
 
     def get(self, t_source, t_sink):
         if isinstance(t_source, int):

--- a/lattice/quark_diagram.py
+++ b/lattice/quark_diagram.py
@@ -90,10 +90,11 @@ class Meson(Particle):
         self.inward = 1
         self.cache = None
 
-    def load(self, key):
+    def load(self, key, usedNe: int = None):
         if self.key != key:
             self.key = key
             self.elemental_data = self.elemental.load(key)
+            self.usedNe = usedNe
             self._make_cache()
 
     def _make_cache(self):
@@ -113,7 +114,7 @@ class Meson(Particle):
                 elemental_coeff, derivative_idx, momentum_idx = elemental_part[j]
                 deriv_mom_tuple = (derivative_idx, momentum_idx)
                 if deriv_mom_tuple not in cache:
-                    cache[deriv_mom_tuple] = self.elemental_data[derivative_idx, momentum_idx]
+                    cache[deriv_mom_tuple] = self.elemental_data[derivative_idx, momentum_idx,  :, :self.usedNe, :self.usedNe]
                 if j == 0:
                     ret_elemental.append(elemental_coeff * cache[deriv_mom_tuple])
                 else:
@@ -152,9 +153,10 @@ class Propagator:
         self.cache_dagger = None
         self.cached_time = None
 
-    def load(self, key):
+    def load(self, key, usedNe:int = None):
         if self.key != key:
             self.key = key
+            self.usedNe = usedNe
             self.perambulator_data = self.perambulator.load(key)
 
     def get(self, t_source, t_sink):
@@ -162,7 +164,7 @@ class Propagator:
 
         if isinstance(t_source, int) and isinstance(t_sink, int):
             if self.cached_time != t_source and self.cached_time != t_sink:
-                self.cache = self.perambulator_data[t_source]
+                self.cache = self.perambulator_data[t_source, :, :, :, :self.usedNe, :self.usedNe]
                 self.cache_dagger = contract("ik,tlkba,lj->tijab", gamma(15), self.cache.conj(), gamma(15))
                 self.cached_time = t_source
             if self.cached_time == t_source:
@@ -171,13 +173,13 @@ class Propagator:
                 return self.cache_dagger[(t_source - t_sink) % self.Lt]
         elif isinstance(t_source, int):
             if self.cached_time != t_source:
-                self.cache = self.perambulator_data[t_source]
+                self.cache = self.perambulator_data[t_source, :, :, :, :self.usedNe, :self.usedNe]
                 self.cache_dagger = contract("ik,tlkba,lj->tijab", gamma(15), self.cache.conj(), gamma(15))
                 self.cached_time = t_source
             return self.cache[(t_sink - t_source) % self.Lt]
         elif isinstance(t_sink, int):
             if self.cached_time != t_sink:
-                self.cache = self.perambulator_data[t_sink]
+                self.cache = self.perambulator_data[t_sink, :, :, :, :self.usedNe, :self.usedNe]
                 self.cache_dagger = contract("ik,tlkba,lj->tijab", gamma(15), self.cache.conj(), gamma(15))
                 self.cached_time = t_sink
             return self.cache_dagger[(t_source - t_sink) % self.Lt]
@@ -192,16 +194,17 @@ class PropagatorLocal:
         self.Lt = Lt
         self.cache = None
 
-    def load(self, key):
+    def load(self, key, usedNe:int = None):
         if self.key != key:
             self.key = key
             self.perambulator_data = self.perambulator.load(key)
+            self.usedNe = usedNe
             self._make_cache()
 
     def _make_cache(self):
-        self.cache = self.perambulator_data[0]
+        self.cache = self.perambulator_data[0, :, :, :, :self.usedNe, :self.usedNe]
         for t_source in range(1, self.Lt):
-            self.cache[t_source] = self.perambulator_data[t_source, 0]
+            self.cache[t_source] = self.perambulator_data[t_source, 0, :, :, :self.usedNe, :self.usedNe]
 
     def get(self, t_source, t_sink):
         if isinstance(t_source, int):


### PR DESCRIPTION
Add support `usedNe` < `Ne` by indicating `usedNe` in `twopt*()` functions or `.load(cfg, usedNe)` in diagrams computing.

 `usedNe` is optional. If not indicate parameter `usedNe`, the total Ne are used.

Tested.